### PR TITLE
Fix IteTypes not initially available

### DIFF
--- a/FPFL-UI/src/app/features/item-detail/shared/services/item-type/item-type.service.ts
+++ b/FPFL-UI/src/app/features/item-detail/shared/services/item-type/item-type.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { catchError } from 'rxjs/internal/operators/catchError';
 import { HttpClient } from '@angular/common/http';
-import { Observable, of, tap } from 'rxjs';
+import { Observable, from, of, tap } from 'rxjs';
 
 import { GlobalErrorHandlerService } from '../../../../../core/services/error/global-error-handler.service';
 import * as auth from '../../../../../../assets/data/auth-config.json';
@@ -28,17 +28,30 @@ export class ItemTypeService {
    * @returns {Observable<IItemType[]>} returns the records
    */
   getItemTypes(): Observable<IItemType[]> {
-    return this.http.get<IItemType[]>(this.url).pipe(
-      tap((itemTypes: IItemType[]) => {
-        this.itemTypes = itemTypes;
-        // console.log(`ItemTypes Service - getItemTypes: ${JSON.stringify(this.itemTypes)}`)
-      }),
-      catchError((err: any) => this.err.handleError(err))
-    );
+    if (this.itemTypes && this.itemTypes.length > 0) {
+      return of(this.itemTypes);
+    } else {
+      this.itemTypes = [...this.generateItemTypes()];
+      return of(this.itemTypes);
+    }
   }
   //#endregion Reads
 
   //#region Utilities
+  /**
+   * Initializes the ItemTypes
+   * @returns {IItemType[]} list
+   */
+  private generateItemTypes(): IItemType[] {
+    // Your logic to generate the list goes here
+    const list: IItemType[] = [
+      { id: 1, name: 'Credit' },
+      { id: 2, name: 'Debit' },
+      { id: 3, name: 'InitialAmount' },
+    ];
+    return list;
+  }
+
   /**
    * Get the ItemType from the ItemTypes List
    * Store value in Session and initialize the "currentItemType"

--- a/FPFL-UI/src/app/features/item-detail/shared/services/item-type/item-type.service.ts
+++ b/FPFL-UI/src/app/features/item-detail/shared/services/item-type/item-type.service.ts
@@ -28,12 +28,10 @@ export class ItemTypeService {
    * @returns {Observable<IItemType[]>} returns the records
    */
   getItemTypes(): Observable<IItemType[]> {
-    if (this.itemTypes && this.itemTypes.length > 0) {
-      return of(this.itemTypes);
-    } else {
+    if (!this.itemTypes || this.itemTypes.length === 0) {
       this.itemTypes = [...this.generateItemTypes()];
-      return of(this.itemTypes);
     }
+    return of(this.itemTypes);
   }
   //#endregion Reads
 


### PR DESCRIPTION
* Fixed bug where ItemTypes were not initially available for Navigation to various Features 
* Cause:  ItemTypes had to be retrieved from API before being available, but since the lowest level of availability of the Azure FPFL SQL Server database is for development, it has to be awakened before use.  This normally takes about 2 minutes.
So when the user clicks on path; Initial Amount, Credits or Debits nothing happens.  This makes for a confusing user experience.
* Solution:  Initialize the ItemTypes array in the Item Types Service on login.  Then when navigation occurs the user is taken to the feature and there will be a Spinner to indicate that the system is working and will have the data shortly.  
